### PR TITLE
RHIDP-3480 fixes typo

### DIFF
--- a/modules/installation/proc-rhdh-deploy-eks-helm.adoc
+++ b/modules/installation/proc-rhdh-deploy-eks-helm.adoc
@@ -4,7 +4,7 @@
 [id='proc-rhdh-deploy-eks-helm_{context}']
 = Installing {product-short} on {eks-short} with the Helm chart
 
-When you install the {product-short} Helm chart in {eks-name} ({eks-short}), it orchestrates the deployment of an {product-short} instance, which provides a robust developer platform within the {aws-short} ecosystem.
+When you install the {product-short} Helm chart in {eks-name} ({eks-short}), it orchestrates the deployment of a {product-short} instance, which provides a robust developer platform within the {aws-short} ecosystem.
 
 .Prerequisites
 


### PR DESCRIPTION
Currently, [1.2. Installing Developer Hub on EKS with the Helm chart](https://dxp-docp-prod.apps.ext-waf.spoke.prod.us-west-2.aws.paas.redhat.com/documentation/en-us/red_hat_developer_hub/1.2/html-single/installing_red_hat_developer_hub_on_amazon_elastic_kubernetes_service/index?lb_target=preview#proc-rhdh-deploy-eks-helm_assembly-install-rhdh-eks) (proc-rhdh-deploy-eks-helm.adoc) says an Developer Hub instance. Replace an with a. 

Note: this typo is common when the {product-very-short} attribute (RHDH) is replaced with the {product-short} attribute (Developer Hub) during a review (e.g. an RHDH instance vs. a Developer Hub instance) but the article is not also changed.